### PR TITLE
Draft: Add environments for new python versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -91,7 +91,7 @@ install:
   - ps: if (${env:platform} -Match "x64") {(get-content c:\projects\omniORB-4.2.5\mk\platforms\x86_win32_vs_${env:MSVCABR}.mk) | foreach-object {$_ -replace "-DEBUG", "-DEBUG -MACHINE:X64"} | set-content c:\projects\omniORB-4.2.5\mk\platforms\x86_win32_vs_${env:MSVCABR}.mk}
   # Edit config to enable the right build, with right Python version
   - ps: (get-content c:\projects\omniORB-4.2.5\config\config.mk) | foreach-object {$_ -replace "\#platform = x86_win32_vs_${env:MSVCABR}", "platform = x86_win32_vs_${env:MSVCABR}"} | set-content c:\projects\omniORB-4.2.5\config\config.mk
-  - ps: (get-content c:\projects\omniORB-4.2.5\mk\platforms\x86_win32_vs_${env:MSVCABR}.mk) | foreach-object {$_ -replace "\#PYTHON = /cygdrive/c/Python36/python", "PYTHON = ${env:PYTHONPATHOMNI}"} | set-content c:\projects\omniORB-4.2.5\mk\platforms\x86_win32_vs_${env:MSVCABR}.mk
+  - ps: (get-content c:\projects\omniORB-4.2.5\mk\platforms\x86_win32_vs_${env:MSVCABR}.mk) | foreach-object {$_ -replace "\#PYTHON = /cygdrive/c/Python37/python", "PYTHON = ${env:PYTHONPATHOMNI}"} | set-content c:\projects\omniORB-4.2.5\mk\platforms\x86_win32_vs_${env:MSVCABR}.mk
 
 build_script:
   - cmd: dir "C:\projects"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,22 @@ environment:
       configuration: Release
       CMAKE_GENERATOR: "Visual Studio 16 2019 Win64"
       MSVCABR: "16"
+      PYTHONPATH: c:\Python310-x64\
+      PYTHONPATHOMNI: "/cygdrive/c/Python310-x64/python"
+      PYVER: "py310"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      ARCH: win32-msvc15
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 16 2019"
+      MSVCABR: "16"
+      PYTHONPATH: c:\Python310\
+      PYTHONPATHOMNI: "/cygdrive/c/Python310/python"
+      PYVER: "py310"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      ARCH: x64-msvc15
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 16 2019 Win64"
+      MSVCABR: "16"
       PYTHONPATH: c:\Python39-x64\
       PYTHONPATHOMNI: "/cygdrive/c/Python39-x64/python"
       PYVER: "py39"
@@ -91,7 +107,7 @@ install:
   - ps: if (${env:platform} -Match "x64") {(get-content c:\projects\omniORB-4.2.5\mk\platforms\x86_win32_vs_${env:MSVCABR}.mk) | foreach-object {$_ -replace "-DEBUG", "-DEBUG -MACHINE:X64"} | set-content c:\projects\omniORB-4.2.5\mk\platforms\x86_win32_vs_${env:MSVCABR}.mk}
   # Edit config to enable the right build, with right Python version
   - ps: (get-content c:\projects\omniORB-4.2.5\config\config.mk) | foreach-object {$_ -replace "\#platform = x86_win32_vs_${env:MSVCABR}", "platform = x86_win32_vs_${env:MSVCABR}"} | set-content c:\projects\omniORB-4.2.5\config\config.mk
-  - ps: (get-content c:\projects\omniORB-4.2.5\mk\platforms\x86_win32_vs_${env:MSVCABR}.mk) | foreach-object {$_ -replace "\#PYTHON = /cygdrive/c/Python37/python", "PYTHON = ${env:PYTHONPATHOMNI}"} | set-content c:\projects\omniORB-4.2.5\mk\platforms\x86_win32_vs_${env:MSVCABR}.mk
+  - ps: (get-content c:\projects\omniORB-4.2.5\mk\platforms\x86_win32_vs_${env:MSVCABR}.mk) | foreach-object {$_ -replace "\#PYTHON = /cygdrive/c/Python3\d+/python", "PYTHON = ${env:PYTHONPATHOMNI}"} | set-content c:\projects\omniORB-4.2.5\mk\platforms\x86_win32_vs_${env:MSVCABR}.mk
 
 build_script:
   - cmd: dir "C:\projects"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,35 +3,35 @@ version: 1.0.{build}
 environment:
   PTHREAD_VERSION: "2.9.2"
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      ARCH: x64-msvc17
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      ARCH: x64-msvc16
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 17 2022 Win64"
-      MSVCABR: "17"
+      CMAKE_GENERATOR: "Visual Studio 16 2019 Win64"
+      MSVCABR: "16"
       PYTHONPATH: c:\Python310-x64\
       PYTHONPATHOMNI: "/cygdrive/c/Python310-x64/python"
       PYVER: "py310"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      ARCH: win32-msvc17
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      ARCH: win32-msvc16
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 17 2022"
-      MSVCABR: "17"
+      CMAKE_GENERATOR: "Visual Studio 16 2019"
+      MSVCABR: "16"
       PYTHONPATH: c:\Python310\
       PYTHONPATHOMNI: "/cygdrive/c/Python310/python"
       PYVER: "py310"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      ARCH: x64-msvc17
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      ARCH: x64-msvc16
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 17 2022 Win64"
-      MSVCABR: "17"
+      CMAKE_GENERATOR: "Visual Studio 16 2019 Win64"
+      MSVCABR: "16"
       PYTHONPATH: c:\Python39-x64\
       PYTHONPATHOMNI: "/cygdrive/c/Python39-x64/python"
       PYVER: "py39"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      ARCH: win32-msvc17
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      ARCH: win32-msvc16
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 17 2022"
-      MSVCABR: "17"
+      CMAKE_GENERATOR: "Visual Studio 16 2019"
+      MSVCABR: "16"
       PYTHONPATH: c:\Python39\
       PYTHONPATHOMNI: "/cygdrive/c/Python39/python"
       PYVER: "py39"
@@ -98,8 +98,8 @@ install:
   - cmd: if %ARCH%==x64-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
   - cmd: if %ARCH%==win32-msvc15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
   - cmd: if %ARCH%==x64-msvc15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-  - cmd: if %ARCH%==win32-msvc17 call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars32.bat"
-  - cmd: if %ARCH%==x64-msvc17 call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - cmd: if %ARCH%==win32-msvc16 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
+  - cmd: if %ARCH%==x64-msvc16 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
 
   - cmd: echo "Generator='%CMAKE_GENERATOR%'"
   - cmd: echo "Platform='%platform%' (set by vcvars batch file)"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,19 +2,19 @@ version: 1.0.{build}
 
 environment:
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       ARCH: x64-msvc15
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
-      MSVCABR: "15"
+      CMAKE_GENERATOR: "Visual Studio 16 2019 Win64"
+      MSVCABR: "16"
       PYTHONPATH: c:\Python39-x64\
       PYTHONPATHOMNI: "/cygdrive/c/Python39-x64/python"
       PYVER: "py39"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       ARCH: win32-msvc15
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 15 2017"
-      MSVCABR: "15"
+      CMAKE_GENERATOR: "Visual Studio 16 2019"
+      MSVCABR: "16"
       PYTHONPATH: c:\Python39\
       PYTHONPATHOMNI: "/cygdrive/c/Python39/python"
       PYVER: "py39"
@@ -54,7 +54,9 @@ environment:
 init:
   # Uncomment next line, to allow RDP access from start
   # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
+  - cmd: echo "List projects"
+  - cmd: dir "C:\projects\"
+  - cmd: cd "C:\"
   # OmniOrb
   - cmd: cd "C:\projects\"
   - appveyor DownloadFile https://downloads.sourceforge.net/project/omniorb/omniORB/omniORB-4.2.5/omniORB-4.2.5.tar.bz2
@@ -77,8 +79,11 @@ install:
   - cmd: set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
   - cmd: if %ARCH%==win32-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
   - cmd: if %ARCH%==x64-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
-  - cmd: if %ARCH%==win32-msvc15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
-  - cmd: if %ARCH%==x64-msvc15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - cmd: if %ARCH%==win32-msvc15 if %MSVCABR%==15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+  - cmd: if %ARCH%==x64-msvc15 if %MSVCABR%==15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - cmd: if %ARCH%==win32-msvc15 if %MSVCABR%==16 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
+  - cmd: if %ARCH%==x64-msvc15 if %MSVCABR%==16 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+
   - cmd: echo "Generator='%CMAKE_GENERATOR%'"
   - cmd: echo "Platform='%platform%' (set by vcvars batch file)"
   # OmniOrb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,36 +1,37 @@
 version: 1.0.{build}
 
 environment:
+  PTHREAD_VERSION: "2.9.2"
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      ARCH: x64-msvc15
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      ARCH: x64-msvc17
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 16 2019 Win64"
-      MSVCABR: "16"
+      CMAKE_GENERATOR: "Visual Studio 17 2022 Win64"
+      MSVCABR: "17"
       PYTHONPATH: c:\Python310-x64\
       PYTHONPATHOMNI: "/cygdrive/c/Python310-x64/python"
       PYVER: "py310"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      ARCH: win32-msvc15
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      ARCH: win32-msvc17
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 16 2019"
-      MSVCABR: "16"
+      CMAKE_GENERATOR: "Visual Studio 17 2022"
+      MSVCABR: "17"
       PYTHONPATH: c:\Python310\
       PYTHONPATHOMNI: "/cygdrive/c/Python310/python"
       PYVER: "py310"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      ARCH: x64-msvc15
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      ARCH: x64-msvc17
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 16 2019 Win64"
-      MSVCABR: "16"
+      CMAKE_GENERATOR: "Visual Studio 17 2022 Win64"
+      MSVCABR: "17"
       PYTHONPATH: c:\Python39-x64\
       PYTHONPATHOMNI: "/cygdrive/c/Python39-x64/python"
       PYVER: "py39"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      ARCH: win32-msvc15
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      ARCH: win32-msvc17
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 16 2019"
-      MSVCABR: "16"
+      CMAKE_GENERATOR: "Visual Studio 17 2022"
+      MSVCABR: "17"
       PYTHONPATH: c:\Python39\
       PYTHONPATHOMNI: "/cygdrive/c/Python39/python"
       PYVER: "py39"
@@ -83,8 +84,8 @@ init:
   - cmd: cd "C:\projects\"
   - cmd: md pthreads-win32
   - cmd: cd "C:\projects\"
-  - appveyor DownloadFile https://github.com/tango-controls/Pthread_WIN32/releases/download/2.9.1/pthreads-win32-2.9.1_%ARCH%.zip
-  - cmd: 7z -y x pthreads-win32-2.9.1_%ARCH%.zip -oC:\projects\pthreads-win32\
+  - appveyor DownloadFile https://github.com/mnabywan/Pthread_WIN32/releases/download/%PTHREAD_VERSION%/pthreads-win32-%PTHREAD_VERSION%_%ARCH%.zip
+  - cmd: 7z -y x pthreads-win32-%PTHREAD_VERSION%_%ARCH%.zip -oC:\projects\pthreads-win32\
 
   # Finally, return to project folder before repo is cloned
   - cmd: cd "C:\projects\omniorb-windows-ci"
@@ -95,10 +96,10 @@ install:
   - cmd: set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
   - cmd: if %ARCH%==win32-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
   - cmd: if %ARCH%==x64-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
-  - cmd: if %ARCH%==win32-msvc15 if %MSVCABR%==15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
-  - cmd: if %ARCH%==x64-msvc15 if %MSVCABR%==15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-  - cmd: if %ARCH%==win32-msvc15 if %MSVCABR%==16 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
-  - cmd: if %ARCH%==x64-msvc15 if %MSVCABR%==16 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - cmd: if %ARCH%==win32-msvc15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+  - cmd: if %ARCH%==x64-msvc15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - cmd: if %ARCH%==win32-msvc17 call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars32.bat"
+  - cmd: if %ARCH%==x64-msvc17 call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
 
   - cmd: echo "Generator='%CMAKE_GENERATOR%'"
   - cmd: echo "Platform='%platform%' (set by vcvars batch file)"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,38 +34,38 @@ environment:
       PYTHONPATH: c:\Python39\
       PYTHONPATHOMNI: "/cygdrive/c/Python39/python"
       PYVER: "py39"
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    #   ARCH: x64-msvc15
-    #   configuration: Release
-    #   CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
-    #   MSVCABR: "15"
-    #   PYTHONPATH: c:\Python37-x64\
-    #   PYTHONPATHOMNI: "/cygdrive/c/Python37-x64/python"
-    #   PYVER: "py37"
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    #   ARCH: win32-msvc15
-    #   configuration: Release
-    #   CMAKE_GENERATOR: "Visual Studio 15 2017"
-    #   MSVCABR: "15"
-    #   PYTHONPATH: c:\Python37\
-    #   PYTHONPATHOMNI: "/cygdrive/c/Python37/python"
-    #   PYVER: "py37"
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    #   ARCH: x64-msvc14
-    #   configuration: Release
-    #   CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
-    #   MSVCABR: "14"
-    #   PYTHONPATH: c:\Python36-x64\
-    #   PYTHONPATHOMNI: "/cygdrive/c/Python36-x64/python"
-    #   PYVER: "py36"
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    #   ARCH: win32-msvc14
-    #   configuration: Release
-    #   CMAKE_GENERATOR: "Visual Studio 14 2015"
-    #   MSVCABR: "14"
-    #   PYTHONPATH: c:\Python36\
-    #   PYTHONPATHOMNI: "/cygdrive/c/Python36/python"
-    #   PYVER: "py36"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x64-msvc15
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
+      MSVCABR: "15"
+      PYTHONPATH: c:\Python37-x64\
+      PYTHONPATHOMNI: "/cygdrive/c/Python37-x64/python"
+      PYVER: "py37"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: win32-msvc15
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 15 2017"
+      MSVCABR: "15"
+      PYTHONPATH: c:\Python37\
+      PYTHONPATHOMNI: "/cygdrive/c/Python37/python"
+      PYVER: "py37"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      ARCH: x64-msvc14
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
+      MSVCABR: "14"
+      PYTHONPATH: c:\Python36-x64\
+      PYTHONPATHOMNI: "/cygdrive/c/Python36-x64/python"
+      PYVER: "py36"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      ARCH: win32-msvc14
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 14 2015"
+      MSVCABR: "14"
+      PYTHONPATH: c:\Python36\
+      PYTHONPATHOMNI: "/cygdrive/c/Python36/python"
+      PYVER: "py36"
   
 init:
   # Uncomment next line, to allow RDP access from start

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,19 +2,19 @@ version: 1.0.{build}
 
 environment:
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       ARCH: x64-msvc15
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 16 2019 Win64"
-      MSVCABR: "16"
+      CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
+      MSVCABR: "15"
       PYTHONPATH: c:\Python39-x64\
       PYTHONPATHOMNI: "/cygdrive/c/Python39-x64/python"
       PYVER: "py39"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       ARCH: win32-msvc15
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 16 2019"
-      MSVCABR: "16"
+      CMAKE_GENERATOR: "Visual Studio 15 2017"
+      MSVCABR: "15"
       PYTHONPATH: c:\Python39\
       PYTHONPATHOMNI: "/cygdrive/c/Python39/python"
       PYVER: "py39"
@@ -77,10 +77,8 @@ install:
   - cmd: set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
   - cmd: if %ARCH%==win32-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
   - cmd: if %ARCH%==x64-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
-  - cmd: if %ARCH%==win32-msvc15 if %MSVCABR%==15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
-  - cmd: if %ARCH%==x64-msvc15 if %MSVCABR%==15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-  - cmd: if %ARCH%==win32-msvc15 if %MSVCABR%==16 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
-  - cmd: if %ARCH%==x64-msvc15 if %MSVCABR%==16 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - cmd: if %ARCH%==win32-msvc15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+  - cmd: if %ARCH%==x64-msvc15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
   - cmd: echo "Generator='%CMAKE_GENERATOR%'"
   - cmd: echo "Platform='%platform%' (set by vcvars batch file)"
   # OmniOrb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,6 +89,8 @@ install:
   - ps: (get-content c:\projects\omniORB-4.2.5\mk\platforms\x86_win32_vs_${env:MSVCABR}.mk) | foreach-object {$_ -replace "\#PYTHON = /cygdrive/c/Python36/python", "PYTHON = ${env:PYTHONPATHOMNI}"} | set-content c:\projects\omniORB-4.2.5\mk\platforms\x86_win32_vs_${env:MSVCABR}.mk
 
 build_script:
+  - cmd: dir "C:\projects"
+  - cmd: dir "C:\"
   - cmd: cd "C:\projects\omniORB-4.2.5\src"
   - cmd: make export
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,38 +2,54 @@ version: 1.0.{build}
 
 environment:
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       ARCH: x64-msvc15
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
-      MSVCABR: "15"
-      PYTHONPATH: c:\Python37-x64\
-      PYTHONPATHOMNI: "/cygdrive/c/Python37-x64/python"
-      PYVER: "py37"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CMAKE_GENERATOR: "Visual Studio 16 2019 Win64"
+      MSVCABR: "16"
+      PYTHONPATH: c:\Python39-x64\
+      PYTHONPATHOMNI: "/cygdrive/c/Python39-x64/python"
+      PYVER: "py39"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       ARCH: win32-msvc15
       configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 15 2017"
-      MSVCABR: "15"
-      PYTHONPATH: c:\Python37\
-      PYTHONPATHOMNI: "/cygdrive/c/Python37/python"
-      PYVER: "py37"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      ARCH: x64-msvc14
-      configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
-      MSVCABR: "14"
-      PYTHONPATH: c:\Python36-x64\
-      PYTHONPATHOMNI: "/cygdrive/c/Python36-x64/python"
-      PYVER: "py36"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      ARCH: win32-msvc14
-      configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 14 2015"
-      MSVCABR: "14"
-      PYTHONPATH: c:\Python36\
-      PYTHONPATHOMNI: "/cygdrive/c/Python36/python"
-      PYVER: "py36"
+      CMAKE_GENERATOR: "Visual Studio 16 2019"
+      MSVCABR: "16"
+      PYTHONPATH: c:\Python39\
+      PYTHONPATHOMNI: "/cygdrive/c/Python39/python"
+      PYVER: "py39"
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    #   ARCH: x64-msvc15
+    #   configuration: Release
+    #   CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
+    #   MSVCABR: "15"
+    #   PYTHONPATH: c:\Python37-x64\
+    #   PYTHONPATHOMNI: "/cygdrive/c/Python37-x64/python"
+    #   PYVER: "py37"
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    #   ARCH: win32-msvc15
+    #   configuration: Release
+    #   CMAKE_GENERATOR: "Visual Studio 15 2017"
+    #   MSVCABR: "15"
+    #   PYTHONPATH: c:\Python37\
+    #   PYTHONPATHOMNI: "/cygdrive/c/Python37/python"
+    #   PYVER: "py37"
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #   ARCH: x64-msvc14
+    #   configuration: Release
+    #   CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
+    #   MSVCABR: "14"
+    #   PYTHONPATH: c:\Python36-x64\
+    #   PYTHONPATHOMNI: "/cygdrive/c/Python36-x64/python"
+    #   PYVER: "py36"
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #   ARCH: win32-msvc14
+    #   configuration: Release
+    #   CMAKE_GENERATOR: "Visual Studio 14 2015"
+    #   MSVCABR: "14"
+    #   PYTHONPATH: c:\Python36\
+    #   PYTHONPATHOMNI: "/cygdrive/c/Python36/python"
+    #   PYVER: "py36"
   
 init:
   # Uncomment next line, to allow RDP access from start
@@ -61,8 +77,10 @@ install:
   - cmd: set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
   - cmd: if %ARCH%==win32-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
   - cmd: if %ARCH%==x64-msvc14 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
-  - cmd: if %ARCH%==win32-msvc15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
-  - cmd: if %ARCH%==x64-msvc15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - cmd: if %ARCH%==win32-msvc15 if %MSVCABR%==15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+  - cmd: if %ARCH%==x64-msvc15 if %MSVCABR%==15 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - cmd: if %ARCH%==win32-msvc15 if %MSVCABR%==16 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
+  - cmd: if %ARCH%==x64-msvc15 if %MSVCABR%==16 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
   - cmd: echo "Generator='%CMAKE_GENERATOR%'"
   - cmd: echo "Platform='%platform%' (set by vcvars batch file)"
   # OmniOrb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,22 @@ environment:
       configuration: Release
       CMAKE_GENERATOR: "Visual Studio 16 2019 Win64"
       MSVCABR: "16"
+      PYTHONPATH: c:\Python311-x64\
+      PYTHONPATHOMNI: "/cygdrive/c/Python311-x64/python"
+      PYVER: "py311"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      ARCH: win32-msvc16
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 16 2019"
+      MSVCABR: "16"
+      PYTHONPATH: c:\Python311\
+      PYTHONPATHOMNI: "/cygdrive/c/Python311/python"
+      PYVER: "py311"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      ARCH: x64-msvc16
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 16 2019 Win64"
+      MSVCABR: "16"
       PYTHONPATH: c:\Python310-x64\
       PYTHONPATHOMNI: "/cygdrive/c/Python310-x64/python"
       PYVER: "py310"


### PR DESCRIPTION
To create new windows builds for new python versions (https://gitlab.com/tango-controls/pytango/-/issues/437), the omniorb CI needed to be actualized.